### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = ""

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In this project, we built an exclusive clubhouse where members can write embarra
 - Ruby On Rails,
 
 ## Getting Started
-
+[![Run on Repl.it](https://repl.it/badge/github/trekab/members-only)](https://repl.it/github/trekab/members-only)
 To get a local copy up and running follow these simple example steps.
 - git clone git@github.com:trekab/members-only.git
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).